### PR TITLE
[Feature] Affichage de la fiche parcellaire dans la popup des parcelles

### DIFF
--- a/cadastre/www/cadastre.css
+++ b/cadastre/www/cadastre.css
@@ -30,3 +30,17 @@ Toolbar buttons
 #cadastre-content div.menu-content {
     margin-bottom:10px !important;
 }
+
+/*
+Popup
+*/
+.lizmapPopup.olPopup .lizmapPopupContent .cadastre.tab-content h3,
+#map-content .lizmapPopupContent .cadastre.tab-content h3,
+#popupcontent .lizmapPopupContent .cadastre.tab-content h3,
+.lizmapPopup.olPopup .lizmapPopupContent .cadastre.tab-content h4,
+#map-content .lizmapPopupContent .cadastre.tab-content h4,
+#popupcontent .lizmapPopupContent .cadastre.tab-content h4 {
+  color:#2B2B2B  !important;
+  font-size: 20px;
+  font-style: italic;
+}


### PR DESCRIPTION
La fiche parcellaire contient les informations sous forme d'onglet proposées par le plugin cadastre pour QGIS.

* Financé par le conseil Départemental du calvados
