### PR TITLE
[BUGFIX] Add compatibility for Lizmap Web Client >= 3.4.4

### DIFF
--- a/cadastre/classes/lizmapCadastreRequest.class.php
+++ b/cadastre/classes/lizmapCadastreRequest.class.php
@@ -13,6 +13,11 @@ class lizmapCadastreRequest extends lizmapOGCRequest
 {
     protected $tplExceptions = 'cadastre~cadastre_exception';
 
+    public function process_getcapabilities()
+    {
+        return $this->getcapabilities();
+    }
+
     protected function getcapabilities()
     {
         // Get cached session
@@ -84,6 +89,11 @@ class lizmapCadastreRequest extends lizmapOGCRequest
         );
     }
 
+    public function process_createPdf()
+    {
+        return $this->createPdf();
+    }
+
     public function createPdf()
     {
 
@@ -124,6 +134,11 @@ class lizmapCadastreRequest extends lizmapOGCRequest
         );
     }
 
+    public function process_getPdf()
+    {
+        return $this->getPdf();
+    }
+
     public function getPdf()
     {
         // Access control
@@ -146,6 +161,11 @@ class lizmapCadastreRequest extends lizmapOGCRequest
             'data' => $data,
             'cached' => false,
         );
+    }
+
+    public function process_getHtml()
+    {
+        return $this->getHtml();
     }
 
     public function getHtml()


### PR DESCRIPTION
Le module cadastre utilise les classes métier de Lizmap pour lancer les requêtes au serveur QGIS. 
https://github.com/3liz/lizmap-web-client/blob/f080fac81f9bf289450b39e15acbe71b80d59b8d/lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php

Pas de souci avec la version **3.4.3** de Lizmap Web Client (LWC)
Mais le commit suivant https://github.com/3liz/lizmap-web-client/commit/f080fac81f9bf289450b39e15acbe71b80d59b8d
demande une modification du code
Ce PR fournit un premier test pour ajouter une compatibilité à la prochaine version **3.4.4**
