### PR TITLE
Utilisation du paramètre ALLCITIES pour la génération du relevé de propriété

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   - identification de la couche Communes
 * Fonctionnalité: recherche par compte de propriété
 * Recherche par numéro de persone dans la recherche des propriétaires
+* Export du relevé de propriété pour toutes les communes
+  - Si il existe un filtre par login à appliquer à la couche Parceles pour l'utilisateur, l'export est restreint à la commune de la parcelle sélectionnée
+  - Sinon l'export se fait sur toutes les communes
 
 ## 1.6.2 - 2021-06-03
 


### PR DESCRIPTION
Si pour la couche parcelles, il n'existe pas de filtre par login ou que l'utilisateur surcharge cette règle, alors, le relevé de propriété se fait pour toutes les villes, sinon l'utilisateur ne peut obtenir le relevé de propriété que sur la ville de la parcelle choisie.
