### PR TITLE
Use the Project::getLoginFilteredConfig() method

### DIFF
--- a/cadastre/classes/cadastreConfig.class.php
+++ b/cadastre/classes/cadastreConfig.class.php
@@ -45,14 +45,6 @@ class cadastreConfig
     public static function getFilterByLogin($repository, $project, $layerId)
     {
         $p = lizmap::getProject($repository.'~'.$project);
-        if (!$p->hasLoginFilteredLayers()) {
-            return null;
-        }
-
-        $pConfig = $p->getFullCfg();
-        if (!$pConfig->loginFilteredLayers) {
-            return null;
-        }
 
         $qgisLayer = $p->getLayer($layerId);
         if (!$qgisLayer) {
@@ -60,7 +52,8 @@ class cadastreConfig
         }
 
         $layerName = $qgisLayer->getName();
-        if (!property_exists($pConfig->loginFilteredLayers, $layerName)) {
+        $loginFilterConfig = $p->getLoginFilteredConfig($layerName);
+        if (!$loginFilterConfig) {
             return null;
         }
 
@@ -68,6 +61,6 @@ class cadastreConfig
             return null;
         }
 
-        return $pConfig->loginFilteredLayers->{$layerName};
+        return $loginFilterConfig;
     }
 }

--- a/cadastre/classes/cadastreDockable.listener.php
+++ b/cadastre/classes/cadastreDockable.listener.php
@@ -39,9 +39,6 @@
             if ($isCadastreProject
                 and cadastreProfile::checkAccess($profile)
             ) {
-                $lproj = lizmap::getProject($event->repository.'~'.$event->project);
-                $configOptions = $lproj->getOptions();
-                $bp = jApp::config()->urlengine['basePath'];
 
                 // Check if database has MAJIC content or not
                 $hasProprietaire = cadastreProfile::checkTableContent('proprietaire', $profile);


### PR DESCRIPTION
Using the getFullCfg API is a deprecated way to access to the project configuration.




