### PR TITLE
Fix service controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Activation de la fonction de zoom à l'ouverture du formulaire de recherche
 * UI - force le margin bottom des éléments p à 10 pixel dans le formulaire de recherche
+* Message d'erreur si le plugin cadastre n'est pas correctement installé pour QGIS Server
 
 ## 1.7.0 - 2021-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Activation de la fonction de zoom à l'ouverture du formulaire de recherche
 * UI - force le margin bottom des éléments p à 10 pixel dans le formulaire de recherche
 * Message d'erreur si le plugin cadastre n'est pas correctement installé pour QGIS Server
+* Cache navigateur pour les documents PDF de 5 minutes (pour le viewer PDF de Webkit)
 
 ## 1.7.0 - 2021-06-21
 

--- a/cadastre/controllers/service.classic.php
+++ b/cadastre/controllers/service.classic.php
@@ -147,6 +147,7 @@ class serviceCtrl extends jController
             $rep->mimeType = 'application/pdf';
             $rep->content = $pdfs[$tok];
             $rep->doDownload = false;
+            $rep->setLifetime(300);
             $rep->outputFileName = 'cadastre_'.$tok.'.pdf';
         } else {
             $rep = $this->getResponse('zip');
@@ -431,6 +432,7 @@ class serviceCtrl extends jController
                 $rep->mimeType = 'application/pdf';
                 $rep->content = jFile::read($logcontent);
                 $rep->doDownload = false;
+                $rep->setLifetime(300);
                 $rep->outputFileName = 'cadastre_'.$token.'.pdf';
                 unlink($logcontent);
                 unlink($log);

--- a/cadastre/controllers/service.classic.php
+++ b/cadastre/controllers/service.classic.php
@@ -57,6 +57,9 @@ class serviceCtrl extends jController
             );
             $result = $request->process();
             if ($result->code !== 200) {
+                $rep->data = array('status' => 'error', 'message' => 'Cadastre module is not well installed.');
+
+                return $rep;
             }
         }
 

--- a/cadastre/controllers/service.classic.php
+++ b/cadastre/controllers/service.classic.php
@@ -41,7 +41,7 @@ class serviceCtrl extends jController
 
         $p = lizmap::getProject($repository.'~'.$project);
         if (!$p) {
-            $rep->data = array('status' => 'error', 'message' => 'A problem occured while loading project with Lizmap');
+            $rep->data = array('status' => 'error', 'message' => 'A problem occurred while loading project with Lizmap');
 
             return $rep;
         }
@@ -235,7 +235,7 @@ class serviceCtrl extends jController
         $type = $this->param('type');
 
         // Use standard export if the standalone python PDF generator does not exist
-        // The Python script, if available, if run asynchronuously
+        // The Python script, if available, if run asynchronously
         // and a new Export page is shown to show the user the progress
         // If not, use a synchronous call to QGIS Server, which could reach timeouts for big export (commune)
         $standalone_python_script = '/srv/qgis/plugins/cadastre/standalone_export.py';
@@ -258,7 +258,7 @@ class serviceCtrl extends jController
             return $rep;
         }
         if (!$p) {
-            $rep->data = array('status' => 'error', 'message' => 'A problem occured while loading project with Lizmap');
+            $rep->data = array('status' => 'error', 'message' => 'A problem occurred while loading project with Lizmap');
 
             return $rep;
         }
@@ -321,7 +321,7 @@ class serviceCtrl extends jController
             return $rep;
         }
         if (!$p) {
-            $rep->data = array('status' => 'error', 'message' => 'A problem occured while loading project with Lizmap');
+            $rep->data = array('status' => 'error', 'message' => 'A problem occurred while loading project with Lizmap');
 
             return $rep;
         }
@@ -409,7 +409,7 @@ class serviceCtrl extends jController
             return $rep;
         }
         if (!$p) {
-            $rep->data = array('status' => 'error', 'message' => 'A problem occured while loading project with Lizmap');
+            $rep->data = array('status' => 'error', 'message' => 'A problem occurred while loading project with Lizmap');
 
             return $rep;
         }
@@ -476,7 +476,7 @@ class serviceCtrl extends jController
         $repository = $this->param('repository');
         $p = lizmap::getProject($repository.'~'.$project);
         if (!$p) {
-            $rep->data = array('status' => 'error', 'message' => 'A problem occured while loading project with Lizmap');
+            $rep->data = array('status' => 'error', 'message' => 'A problem occurred while loading project with Lizmap');
 
             return $rep;
         }

--- a/cadastre/controllers/service.classic.php
+++ b/cadastre/controllers/service.classic.php
@@ -138,17 +138,16 @@ class serviceCtrl extends jController
             }
             $pdfs[$token] = $result->data;
         }
-        if (count($pdfs) == 1) {
+
+        if (count($pdfs) == 0) {
+            $rep = $this->getResponse('text');
+            $rep->content = 'Erreur de création du relevé.';
+        } elseif (count($pdfs) == 1) {
             $rep = $this->getResponse('binary');
             $rep->mimeType = 'application/pdf';
             $rep->content = $pdfs[$tok];
             $rep->doDownload = false;
             $rep->outputFileName = 'cadastre_'.$tok.'.pdf';
-        } elseif (count($pdfs) == 0) {
-            $rep = $this->getResponse('text');
-            $rep->content = 'Erreur de création du relevé.';
-
-            return $rep;
         } else {
             $rep = $this->getResponse('zip');
             $rep->zipFilename = 'releves_cadastre.zip';


### PR DESCRIPTION
Amélioration du controlleur service : 
* Message d'erreur si le plugin cadastre n'est pas correctement installé
* Spelling
* Réorganisation du code de la méthode getCadastrePdf
* Cache navigateur pour les documents PDF de 5 minutes (pour le viewer PDF de Webkit)