### PR TITLE
[Bugfix] Renvois d'un tableau vide si certains paramètres pour une Datasource sont vide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+* Lorsque certains paramètres de récupération des données du "Datasource" d'un champ Jelix sont vides, on renvoie directement une liste vide.
+
 ## 1.8.2 - 2022-10-15
 
 ### Fixed

--- a/cadastre/classes/listGeoSectionDatasource.class.php
+++ b/cadastre/classes/listGeoSectionDatasource.class.php
@@ -25,6 +25,12 @@ class listGeoSectionDatasource extends jFormsDynamicDatasource
         $repository = $form->getData($this->criteriaFrom[0]);
         $project = $form->getData($this->criteriaFrom[1]);
         $layerId = $form->getData($this->criteriaFrom[2]);
+        $commune = $form->getData($this->criteriaFrom[3]);
+
+        if (empty($commune)) {
+            return array();
+        }
+
         $this->profile = cadastreProfile::getWithLayerId($repository, $project, $layerId);
 
         if ($this->dao === null) {
@@ -32,7 +38,7 @@ class listGeoSectionDatasource extends jFormsDynamicDatasource
         }
 
         $args = array();
-        array_push($args, $form->getData($this->criteriaFrom[3]));
+        array_push($args, $commune);
 
         $config = cadastreConfig::get($repository, $project);
         $condition = cadastreConfig::getLayerSql($repository, $project, $config->section->id);

--- a/cadastre/classes/listParcelleLieuDatasource.class.php
+++ b/cadastre/classes/listParcelleLieuDatasource.class.php
@@ -27,6 +27,11 @@ class listParcelleLieuDatasource extends jFormsDynamicDatasource
         $layerId = $form->getData($this->criteriaFrom[2]);
         $section = $form->getData($this->criteriaFrom[3]);
         $voie = $form->getData($this->criteriaFrom[4]);
+
+        if (empty($section) && empty($voie)) {
+            return array();
+        }
+
         $this->profile = cadastreProfile::getWithLayerId($repository, $project, $layerId);
 
         if ($this->dao === null) {

--- a/cadastre/classes/listParcelleLieuNoMajicDatasource.class.php
+++ b/cadastre/classes/listParcelleLieuNoMajicDatasource.class.php
@@ -26,6 +26,11 @@ class listParcelleLieuNoMajicDatasource extends jFormsDynamicDatasource
         $project = $form->getData($this->criteriaFrom[1]);
         $layerId = $form->getData($this->criteriaFrom[2]);
         $section = $form->getData($this->criteriaFrom[3]);
+
+        if (empty($section)) {
+            return array();
+        }
+
         $this->profile = cadastreProfile::getWithLayerId($repository, $project, $layerId);
 
         if ($this->dao === null) {

--- a/cadastre/classes/listParcellePropDatasource.class.php
+++ b/cadastre/classes/listParcellePropDatasource.class.php
@@ -32,14 +32,16 @@ class listParcellePropDatasource extends jFormsDynamicDatasource
         $comptecommunal = $form->getData($this->criteriaFrom[4]);
         $compte = $form->getData($this->criteriaFrom[5]);
 
-        $result = array();
-
         if (empty($commune) && empty($comptecommunal)) {
-            return $result;
+            return array();
         }
 
-        if (!empty($compte)) {
+        if (!empty($commune) && !empty($compte)) {
             $comptecommunal = $commune . $compte;
+        }
+
+        if (empty($comptecommunal)) {
+            return array();
         }
 
         $this->profile = cadastreProfile::getWithLayerId($repository, $project, $layerId);
@@ -76,6 +78,8 @@ class listParcellePropDatasource extends jFormsDynamicDatasource
             array_push($args, $condition);
             $found = call_user_func_array(array($this->dao, $method), $args);
         }
+
+        $result = array();
 
         foreach ($found as $obj) {
             $label = $this->buildLabel($obj);


### PR DESCRIPTION
Lorsque certains paramètres de Datasource::getData sont vides, il n'est pas nécessaire de calculer et exécuter une requête, spécialement pour les Parcelles.

Funded by Calvados https://www.calvados.fr
